### PR TITLE
CHECKEATMX-207: falla el gps en los emuladores con android 7.0

### DIFF
--- a/location/src/main/java/com/checkeat/location/framework/location/GPSLocation.kt
+++ b/location/src/main/java/com/checkeat/location/framework/location/GPSLocation.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.location.Geocoder
 import android.location.Location
 import android.location.LocationListener
+import android.util.Log
 import java.util.*
 
 typealias CheckEatLocation = com.checkeat.location.lib.model.Location
@@ -21,13 +22,25 @@ class GPSLocation(
     private fun retrieveLocation(location: Location): CheckEatLocation {
         val geocoder = Geocoder(context, locale)
         val addresses = geocoder.getFromLocation(location.latitude, location.longitude, 1)
-        return CheckEatLocation(
+
+        if (addresses.size != 0) {
+            return CheckEatLocation(
                 id = 0,
                 address = addresses[0].getAddressLine(0),
                 latitude = location.latitude,
                 longitude = location.longitude,
                 city = addresses[0].locality,
                 province = addresses[0].adminArea
-        )
+            )
+        } else {
+            return CheckEatLocation(
+                id = 0,
+                address = "null",
+                latitude = 0.000000000000000,
+                longitude = 0.000000000000000,
+                city = "null",
+                province = "null"
+            )
+        }
     }
 }


### PR DESCRIPTION
Hice este cambio por que cuando abrí por primera vez el proyecto en mi computadora y ejecuté el app en el emulador de Android Studio con el sistema operativo de android 7.0, presioné el botón de "Location based on GPS" y la app se crasheó.

Mi solución:
En caso de que el emulador aún no haya establecido una ubicación dentro del GPS, para evitar errores la aplicación manda una ubicación por defecto para prevenir que se cierre la app.